### PR TITLE
Partial fix for hover issues

### DIFF
--- a/src/app/app.component.less
+++ b/src/app/app.component.less
@@ -3,5 +3,5 @@ p {
 }
 
 multi-line-chart {
-  width: 500px;
+  width: 800px;
 }

--- a/src/app/multi-line-chart/multi-line-chart.component.ts
+++ b/src/app/multi-line-chart/multi-line-chart.component.ts
@@ -127,7 +127,7 @@ export class MultiLineChartComponent implements OnInit {
         // @ts-ignore
         const i = xm - data.dates[i0] > data.dates[i1] - xm ? i1 : i0;
         const s = (d3Array as any).least(data.series, d =>
-          Math.abs(d.values[i] - ym)
+          Math.abs(Math.log10(d.values[i]) - Math.log10(ym))
         );
         path
           .attr('stroke', d => (d === s ? null : '#ddd'))


### PR DESCRIPTION
You can see that in the X direction (probably also in the Y direction, but hard to see visually) the hover dot is actually a few pixels to the right of the cursor. Probably we can fix this buy considering the bounding box of the element (currently I think this looks at the mouse's absolute coordinates), but in any case this is definitely an improvement!

![hover](https://user-images.githubusercontent.com/3111845/77974428-f72b3700-72ab-11ea-8eb5-71b88dd8dee7.gif)
