### PR TITLE
Add gridlines; Add options for setting bounds; Tweak axes; Minor things

### DIFF
--- a/src/app/multi-line-chart/multi-line-chart.component.ts
+++ b/src/app/multi-line-chart/multi-line-chart.component.ts
@@ -25,8 +25,8 @@ export class MultiLineChartComponent implements OnInit {
   @Input() xAxisBounds?: [number, number];
   @Input() yAxisBounds?: [number, number];
 
-  private x: d3.ScaleContinuousNumeric<number, number>;
-  private y: d3.ScaleContinuousNumeric<number, number>;
+  private xScale: d3.ScaleContinuousNumeric<number, number>;
+  private yScale: d3.ScaleContinuousNumeric<number, number>;
 
   constructor(private elementRef: ElementRef) {}
 
@@ -48,24 +48,24 @@ export class MultiLineChartComponent implements OnInit {
       dates: times(Math.max(...this.data.map(v => v.values.length)), Number),
     };
 
-    this.y = d3
+    this.yScale = d3
       .scaleLog()
       .domain(
         this.yAxisBounds || [1, d3.max(data.series, d => d3.max(d.values))]
       )
       .range([height - margin.bottom, margin.top]);
 
-    this.x = d3
+    this.xScale = d3
       .scaleLinear()
       .domain(this.xAxisBounds || d3.extent(data.dates as Number[]))
       .range([margin.left, width - margin.right]);
 
-    console.log(this.x.domain(), this.y.domain());
+    console.log(this.xScale.domain(), this.yScale.domain());
 
     const xAxis = g =>
       g.attr('transform', `translate(0,${height - margin.bottom})`).call(
         d3
-          .axisBottom(this.x)
+          .axisBottom(this.xScale)
           .tickValues(this.getDayTicks())
           .tickSizeOuter(0)
       );
@@ -73,7 +73,7 @@ export class MultiLineChartComponent implements OnInit {
     const yAxis = g =>
       g.attr('transform', `translate(${margin.left},0)`).call(
         d3
-          .axisLeft(this.y)
+          .axisLeft(this.yScale)
           .tickValues(this.getCasesTicks())
           .tickFormat(x => x.toLocaleString())
       );
@@ -81,8 +81,8 @@ export class MultiLineChartComponent implements OnInit {
     const line = d3
       .line()
       .defined(d => !isNaN(d as any))
-      .x((d, i) => this.x(data.dates[i]))
-      .y(d => this.y(d as any));
+      .x((d, i) => this.xScale(data.dates[i]))
+      .y(d => this.yScale(d as any));
 
     function hover(svg, path) {
       if ('ontouchstart' in document)
@@ -112,8 +112,8 @@ export class MultiLineChartComponent implements OnInit {
         const boundingRect = (self.elementRef
           .nativeElement as Element).getBoundingClientRect();
         d3.event.preventDefault();
-        const ym = self.y.invert(d3.event.layerY - boundingRect.top);
-        const xm = self.x.invert(d3.event.layerX - boundingRect.left);
+        const ym = self.yScale.invert(d3.event.layerY - boundingRect.top);
+        const xm = self.xScale.invert(d3.event.layerX - boundingRect.left);
         const i1 = d3.bisectLeft(data.dates, xm, 1);
         const i0 = i1 - 1;
         // @ts-ignore
@@ -127,7 +127,7 @@ export class MultiLineChartComponent implements OnInit {
           .raise();
         dot.attr(
           'transform',
-          `translate(${self.x(data.dates[i])},${self.y(s.values[i])})`
+          `translate(${self.xScale(data.dates[i])},${self.yScale(s.values[i])})`
         );
         const comment = s.comments ? '— ' + s.comments[i] : '';
         dot
@@ -193,8 +193,8 @@ export class MultiLineChartComponent implements OnInit {
               .selectAll('line')
               .data(self.getDayTicks())
               .join('line')
-              .attr('x1', d => 0.5 + self.x(d))
-              .attr('x2', d => 0.5 + self.x(d))
+              .attr('x1', d => 0.5 + self.xScale(d))
+              .attr('x2', d => 0.5 + self.xScale(d))
               .attr('y1', margin.top)
               .attr('y2', height - margin.bottom)
           )
@@ -204,8 +204,8 @@ export class MultiLineChartComponent implements OnInit {
               .selectAll('line')
               .data(self.getCasesTicks())
               .join('line')
-              .attr('y1', d => 0.5 + self.y(d))
-              .attr('y2', d => 0.5 + self.y(d))
+              .attr('y1', d => 0.5 + self.yScale(d))
+              .attr('y2', d => 0.5 + self.yScale(d))
               .attr('x1', margin.left)
               .attr('x2', width - margin.right)
           )
@@ -220,7 +220,7 @@ export class MultiLineChartComponent implements OnInit {
   }
 
   private getDayTicks(): number[] {
-    const [min, max] = this.x.domain();
+    const [min, max] = this.xScale.domain();
     const result = [];
     for (let i = 0; i <= max; i += 7) {
       if (i >= min) {
@@ -231,7 +231,7 @@ export class MultiLineChartComponent implements OnInit {
   }
 
   private getCasesTicks(): number[] {
-    const [min, max] = this.y.domain();
+    const [min, max] = this.yScale.domain();
     const result = [];
     for (let i = 1; i <= max; i *= 10) {
       if (i >= min) {

--- a/src/app/multi-line-chart/multi-line-chart.component.ts
+++ b/src/app/multi-line-chart/multi-line-chart.component.ts
@@ -39,7 +39,7 @@ export class MultiLineChartComponent implements OnInit {
     const width = 800;
     const height = 600;
 
-    const margin = { top: 20, right: 20, bottom: 30, left: 30 };
+    const margin = { top: 20, right: 20, bottom: 30, left: 60 };
 
     const data = {
       y: this.yAxisLabel,
@@ -51,7 +51,7 @@ export class MultiLineChartComponent implements OnInit {
     this.y = d3
       .scaleLog()
       .domain(
-        this.yAxisBounds || [2, d3.max(data.series, d => d3.max(d.values))]
+        this.yAxisBounds || [1, d3.max(data.series, d => d3.max(d.values))]
       )
       .range([height - margin.bottom, margin.top]);
 
@@ -66,15 +66,17 @@ export class MultiLineChartComponent implements OnInit {
       g.attr('transform', `translate(0,${height - margin.bottom})`).call(
         d3
           .axisBottom(this.x)
-          .ticks(width / 80)
+          .tickValues(this.getDayTicks())
           .tickSizeOuter(0)
       );
 
     const yAxis = g =>
-      g
-        .attr('transform', `translate(${margin.left},0)`)
-        .call(d3.axisLeft(this.y))
-        .call(g => g.select('.domain').remove());
+      g.attr('transform', `translate(${margin.left},0)`).call(
+        d3
+          .axisLeft(this.y)
+          .tickValues(this.getCasesTicks())
+          .tickFormat(x => x.toLocaleString())
+      );
 
     const line = d3
       .line()
@@ -128,7 +130,9 @@ export class MultiLineChartComponent implements OnInit {
           `translate(${self.x(data.dates[i])},${self.y(s.values[i])})`
         );
         const comment = s.comments ? '— ' + s.comments[i] : '';
-        dot.select('text').text(`${s.name}: ${s.values[i]}${comment}`);
+        dot
+          .select('text')
+          .text(`${s.name}: ${s.values[i].toLocaleString()}${comment}`);
       }
 
       function entered() {
@@ -184,5 +188,27 @@ export class MultiLineChartComponent implements OnInit {
     }
 
     this.elementRef.nativeElement.appendChild(makeChart());
+  }
+
+  private getDayTicks(): number[] {
+    const [min, max] = this.x.domain();
+    const result = [];
+    for (let i = 0; i <= max; i += 7) {
+      if (i >= min) {
+        result.push(i);
+      }
+    }
+    return result;
+  }
+
+  private getCasesTicks(): number[] {
+    const [min, max] = this.y.domain();
+    const result = [];
+    for (let i = 1; i <= max; i *= 10) {
+      if (i >= min) {
+        result.push(i);
+      }
+    }
+    return result;
   }
 }

--- a/src/app/multi-line-chart/multi-line-chart.component.ts
+++ b/src/app/multi-line-chart/multi-line-chart.component.ts
@@ -53,13 +53,11 @@ export class MultiLineChartComponent implements OnInit {
       .domain(
         this.yAxisBounds || [2, d3.max(data.series, d => d3.max(d.values))]
       )
-      .nice()
       .range([height - margin.bottom, margin.top]);
 
     this.x = d3
       .scaleLinear()
       .domain(this.xAxisBounds || d3.extent(data.dates as Number[]))
-      .nice()
       .range([margin.left, width - margin.right]);
 
     console.log(this.x.domain(), this.y.domain());

--- a/src/app/multi-line-chart/multi-line-chart.component.ts
+++ b/src/app/multi-line-chart/multi-line-chart.component.ts
@@ -22,6 +22,8 @@ export class MultiLineChartComponent implements OnInit {
   // - all the serieses are of the same length & the same dates
   @Input() data: Series[];
   @Input() animate: boolean = false;
+  @Input() xAxisBounds?: [number, number];
+  @Input() yAxisBounds?: [number, number];
 
   private x: d3.ScaleContinuousNumeric<number, number>;
   private y: d3.ScaleContinuousNumeric<number, number>;
@@ -48,13 +50,15 @@ export class MultiLineChartComponent implements OnInit {
 
     this.y = d3
       .scaleLog()
-      .domain([2, d3.max(data.series, d => d3.max(d.values))])
+      .domain(
+        this.yAxisBounds || [2, d3.max(data.series, d => d3.max(d.values))]
+      )
       .nice()
       .range([height - margin.bottom, margin.top]);
 
     this.x = d3
       .scaleLinear()
-      .domain(d3.extent(data.dates as Number[]))
+      .domain(this.xAxisBounds || d3.extent(data.dates as Number[]))
       .nice()
       .range([margin.left, width - margin.right]);
 

--- a/src/app/multi-line-chart/multi-line-chart.component.ts
+++ b/src/app/multi-line-chart/multi-line-chart.component.ts
@@ -182,6 +182,35 @@ export class MultiLineChartComponent implements OnInit {
         });
       }
 
+      // Grid lines
+      svg.append('g').call(g =>
+        g
+          .attr('stroke', 'black')
+          .attr('stroke-opacity', 0.1)
+          .call(g =>
+            g
+              .append('g')
+              .selectAll('line')
+              .data(self.getDayTicks())
+              .join('line')
+              .attr('x1', d => 0.5 + self.x(d))
+              .attr('x2', d => 0.5 + self.x(d))
+              .attr('y1', margin.top)
+              .attr('y2', height - margin.bottom)
+          )
+          .call(g =>
+            g
+              .append('g')
+              .selectAll('line')
+              .data(self.getCasesTicks())
+              .join('line')
+              .attr('y1', d => 0.5 + self.y(d))
+              .attr('y2', d => 0.5 + self.y(d))
+              .attr('x1', margin.left)
+              .attr('x2', width - margin.right)
+          )
+      );
+
       svg.call(hover, path);
 
       return svg.node();

--- a/src/app/multi-line-chart/multi-line-chart.component.ts
+++ b/src/app/multi-line-chart/multi-line-chart.component.ts
@@ -57,39 +57,18 @@ export class MultiLineChartComponent implements OnInit {
       .range([margin.left, width - margin.right]);
 
     const xAxis = g =>
-      g
-        .attr('transform', `translate(0,${height - margin.bottom})`)
-        .call(
-          d3
-            .axisBottom(x)
-            .ticks(width / 80)
-            .tickSizeOuter(0)
-        )
-        .call(g =>
-          g
-            .select('.tick:last-of-type text')
-            .clone()
-            .attr('y', 30)
-            .attr('x', -70)
-            .attr('text-anchor', 'start')
-            .attr('font-weight', 'bold')
-            .text(data.x)
-        );
+      g.attr('transform', `translate(0,${height - margin.bottom})`).call(
+        d3
+          .axisBottom(x)
+          .ticks(width / 80)
+          .tickSizeOuter(0)
+      );
 
     const yAxis = g =>
       g
         .attr('transform', `translate(${margin.left},0)`)
         .call(d3.axisLeft(y))
-        .call(g => g.select('.domain').remove())
-        .call(g =>
-          g
-            .select('.tick:last-of-type text')
-            .clone()
-            .attr('x', 10)
-            .attr('text-anchor', 'start')
-            .attr('font-weight', 'bold')
-            .text(data.y)
-        );
+        .call(g => g.select('.domain').remove());
 
     const line = d3
       .line()


### PR DESCRIPTION
See individual commits for details. The main things are:
- Added gridlines
- Added options for setting bounds
- x axis now has ticks every 7 days
- y axis now has ticks every factor of 10 (previously there were more intermediate ticks)

I removed the axis labels because I didn't feel like figuring out how to get them to be positioned correctly right this moment 😅 my tick tweaks affected that

<img width="880" alt="Screen Shot 2020-04-01 at 10 03 19 PM" src="https://user-images.githubusercontent.com/3111845/78212594-0dc8be00-7465-11ea-96ec-1decb1d91511.png">
