### PR TITLE
Hover tweaks

### DIFF
--- a/src/app/graph-data.service.ts
+++ b/src/app/graph-data.service.ts
@@ -88,7 +88,7 @@ const fetchGraphData = (graphDefinitions: CovidGraphDefinition[]) =>
                 return {
                   name: location,
                   values: locationData.map((l) => parseInt(l[data_type], 10)),
-                  comments: locationData.map((l) => l.date.toISOString()),
+                  comments: locationData.map((l) => l.date.toDateString()),
                 };
               } catch (e) {
                 console.error(`Location ${location} is invalid`);

--- a/src/app/multi-line-chart/multi-line-chart.component.ts
+++ b/src/app/multi-line-chart/multi-line-chart.component.ts
@@ -131,7 +131,7 @@ export class MultiLineChartComponent implements OnInit {
           'transform',
           `translate(${self.xScale(self.dates[i])},${self.yScale(s.values[i])})`
         );
-        const comment = s.comments ? '— ' + s.comments[i] : '';
+        const comment = s.comments ? ' — ' + s.comments[i] : '';
         dot
           .select('text')
           .text(`${s.name}: ${s.values[i].toLocaleString()}${comment}`);

--- a/src/app/multi-line-chart/multi-line-chart.component.ts
+++ b/src/app/multi-line-chart/multi-line-chart.component.ts
@@ -39,6 +39,8 @@ export class MultiLineChartComponent implements OnInit {
   private margin = { top: 20, right: 20, bottom: 30, left: 60 };
   private dates: number[];
 
+  private svg: SVGSVGElement;
+
   constructor(
     private elementRef: ElementRef,
     private colorService: ColorService
@@ -113,8 +115,7 @@ export class MultiLineChartComponent implements OnInit {
         .attr('y', -8);
 
       function moved() {
-        const boundingRect = (self.elementRef
-          .nativeElement as Element).getBoundingClientRect();
+        const boundingRect = self.svg.getBoundingClientRect();
         d3.event.preventDefault();
         const ym = self.yScale.invert(d3.event.layerY - boundingRect.top);
         const xm = self.xScale.invert(d3.event.layerX - boundingRect.left);
@@ -239,7 +240,9 @@ export class MultiLineChartComponent implements OnInit {
       return svg.node();
     }
 
-    this.elementRef.nativeElement.appendChild(makeChart());
+    this.svg = makeChart();
+
+    this.elementRef.nativeElement.appendChild(this.svg);
   }
 
   private getDayTicks(): number[] {


### PR DESCRIPTION
Main changes:

- Bugfix for wrong-coordinates issue introduced in #13 
- Just show date, not time

<img width="643" alt="Screen Shot 2020-04-25 at 5 00 23 PM" src="https://user-images.githubusercontent.com/3111845/80293701-69a9fe00-8716-11ea-9dc1-f7699f637eaf.png">
