### PR TITLE
WIP: Short location names ("Alameda County" instead of "Alameda County, California, United States")

### DIFF
--- a/src/app/graph-data.service.ts
+++ b/src/app/graph-data.service.ts
@@ -86,7 +86,7 @@ const fetchGraphData = (graphDefinitions: CovidGraphDefinition[]) =>
                     parseTimeseriesData(data, data_type, cutoff)
                   );
                 return {
-                  name: location,
+                  name: location.split(',')[0],
                   values: locationData.map((l) => parseInt(l[data_type], 10)),
                   comments: locationData.map((l) => l.date.toISOString()),
                 };


### PR DESCRIPTION
AFAICT, CDS location names are always hierarchical like this, so it makes sense to `.split(',')[0]`. Do you know if NYT location names are as well?

(If they are not, darn -- more complicated. If they are, I should add a comment explaining this before merging lol)

Side effect: Colors change as a result of names changing

<img width="645" alt="Screen Shot 2020-04-25 at 5 00 43 PM" src="https://user-images.githubusercontent.com/3111845/80293719-89412680-8716-11ea-8fcf-6aa5b06470d9.png">
